### PR TITLE
Do not fail if room.name is null

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,7 +100,7 @@ class App extends MatrixPuppetBridgeBase {
     const directTopic = () => `Slack Direct Message (Team: ${this.teamName})`
     const room = this.client.getRoomById(id);
     return {
-      name: room.name,
+      name: room.name ? room.name : "Room name unavailable",
       topic: room.isDirect ? directTopic() : room.purpose.value
     }
   }


### PR DESCRIPTION
Hey,

as discussed on Matrix ( https://matrix.to/#/!ChuQQIVJvwyJujhNIG:synapse.keyvan.pw/$148908051834345owlgv:utzutzutz.net ) I sometimes do not receive direct messages from slack in Matrix.

I traced it to room.name being null. This patch works around it by returning a string to avoid the error.
This is not a proper fix but better then not knowing that someone tried to contact you.