### PR TITLE
Polish the slack puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Restart your HS.
  - Slack -> Matrix
    - [x] Text content
    - [x] Image/Audio/Video content as protected link to slack
-   - [ ] Image/Audio/Video content as upload & embed to matrix
+   - [x] Image/Audio/Video content as upload & embed to matrix
    - [ ] Typing notifs
    - [ ] User Profiles
    - [ ] Presence

--- a/app.js
+++ b/app.js
@@ -58,19 +58,86 @@ class App extends MatrixPuppetBridgeBase {
           channel: data.channel,
           text: `Edit: ${data.message.text}`,
           user: data.message.user
-        })
+        });
       } else {
-        this.createAndSendPayload({
-          channel: data.channel,
-          text: data.text,
-          attachments: data.attachments,
-          bot_id: data.bot_id,
-          user: data.user,
-          user_profile: data.user_profile,
-        })
+        if (data.file) {
+          this.sendFile(data).then(() => {
+            if (data.file.initial_comment) {
+              this.createAndSendPayload({
+                channel: data.channel,
+                text: data.file.initial_comment.comment,
+                attachments: data.attachments,
+                bot_id: data.bot_id,
+                user: data.user,
+                user_profile: data.user_profile,
+              });
+            }
+          });
+        } else {
+          this.createAndSendPayload({
+            channel: data.channel,
+            text: data.text,
+            attachments: data.attachments,
+            bot_id: data.bot_id,
+            user: data.user,
+            user_profile: data.user_profile,
+          });
+        }
       }
     });
     debug('registered message listener');
+  }
+  getPayload(data) {
+    const {
+      channel,
+      text,
+      attachments,
+      bot_id,
+      user,
+      user_profile,
+      file,
+    } = data;
+    let payload = { roomId: channel };
+    
+    if (user) {
+      if ( user === "USLACKBOT" ) {
+        payload.senderName = user_profile.name;
+        payload.senderId = user;
+        payload.avatarUrl = user_profile.image_72;
+      } else {
+        const isMe = user === this.client.getSelfUserId();
+        let uu = this.client.getUserById(user);
+        payload.senderId = isMe ? undefined : user;
+        if (uu) {
+          payload.senderName = uu.name;
+          payload.avatarUrl = uu.profile.image_512;
+        } else {
+          payload.senderName = "unknown";
+        }
+      }
+    } else if (bot_id) {
+      const bot = this.client.getBotById(bot_id);
+      payload.senderName = bot.name;
+      payload.senderId = bot_id;
+      payload.avatarUrl = bot.icons.image_72
+    }
+    return payload;
+  }
+  sendFile(data) {
+    let payload = this.getPayload(data);
+    payload.text = data.file.name;
+    payload.url = ''; // to prevent errors
+    return this.client.downloadImage(data.file.url_private).then(({ buffer, type }) => {
+      console.log(buffer);
+      console.log(buffer.toString('utf-8'));
+      payload.buffer = buffer;
+      payload.mimetype = type;
+      return this.handleThirdPartyRoomImageMessage(payload);
+    }).catch((err) => {
+      console.log(err);
+      payload.text = '[Image] ('+data.name+') '+data.url;
+      return this.handleThirdPartyRoomMessage(payload);
+    });
   }
   createAndSendPayload(data) {
     const {
@@ -80,6 +147,7 @@ class App extends MatrixPuppetBridgeBase {
       bot_id,
       user,
       user_profile,
+      file,
     } = data;
     // any direct text
     let messages = [text];
@@ -87,7 +155,7 @@ class App extends MatrixPuppetBridgeBase {
     if (attachments) attachments.forEach(att=> messages.push(att.text))
 
     const rawMessage = messages.join('\n').trim();
-    let payload = { roomId: channel };
+    let payload = this.getPayload(data);
 
     try {
       payload.text = slackdown(rawMessage, this.client.getUsers(), this.client.getChannels());
@@ -97,23 +165,7 @@ class App extends MatrixPuppetBridgeBase {
       payload.text = rawMessage;
     }
 
-    // lastly, determine the sender
-    if (user) {
-      if ( user === "USLACKBOT" ) {
-        payload.senderName = user_profile.name;
-        payload.senderId = user;
-        payload.avatarUrl = user_profile.image_72;
-      } else {
-        const isMe = user === this.client.getSelfUserId();
-        payload.senderName = this.client.getUserById(user).name;
-        payload.senderId = isMe ? undefined : user;
-      }
-    } else if (bot_id) {
-      const bot = this.client.getBotById(bot_id);
-      payload.senderName = bot.name;
-      payload.senderId = bot_id;
-      payload.avatarUrl = bot.icons.image_72
-    }
+    
 
     return this.handleThirdPartyRoomMessage(payload).catch(err=>{
       console.error(err);
@@ -134,12 +186,15 @@ class App extends MatrixPuppetBridgeBase {
       topic: room.isDirect ? directTopic() : room.purpose.value
     }
   }
+  sendReadReceiptAsPuppetToThirdPartyRoomWithId() {
+    // not available for now
+  }
   sendMessageAsPuppetToThirdPartyRoomWithId(id, text) {
     debug('sending message as puppet to third party room with id', id);
     return this.client.sendMessage(text, id);
   }
-  sendPictureMessageAsPuppetToThirdPartyRoomWithId(thirdPartyRoomId, messageText, imageFile, matrixEvent, publicImageUrl) {
-    return this.client.sendPictureMessage(publicImageUrl, thirdPartyRoomId);
+  sendImageMessageAsPuppetToThirdPartyRoomWithId(id, data) {
+    return this.client.sendImageMessage(data.url, data.text, id);
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -165,6 +165,11 @@ class App extends MatrixPuppetBridgeBase {
         [':hankey:', ':poop:'],
         [':slightly_smiling_face:', ':slight_smile:'],
         [':upside_down_face:', ':upside_down:'],
+        [':skin-tone-2:', '🏻'],
+        [':skin-tone-3:', '🏼'],
+        [':skin-tone-4:', '🏽'],
+        [':skin-tone-5:', '🏾'],
+        [':skin-tone-6:', '🏿'],
       ];
       for (let i = 0; i < replacements.length; i++) {
         rawMessage = rawMessage.replace(replacements[i][0], replacements[i][1]);

--- a/app.js
+++ b/app.js
@@ -194,6 +194,7 @@ class App extends MatrixPuppetBridgeBase {
     return this.client.sendMessage(text, id);
   }
   sendImageMessageAsPuppetToThirdPartyRoomWithId(id, data) {
+    console.log(data);
     return this.client.sendImageMessage(data.url, data.text, id);
   }
 }

--- a/client.js
+++ b/client.js
@@ -2,6 +2,7 @@ const debug = require('debug')('matrix-puppet:slack:client');
 const Promise = require('bluebird');
 const EventEmitter = require('events').EventEmitter;
 const { WebClient, RtmClient, CLIENT_EVENTS } = require('@slack/client');
+const { download } = require('./utils');
 
 class Client extends EventEmitter {
   constructor(token) {
@@ -45,6 +46,7 @@ class Client extends EventEmitter {
           require('fs').writeFileSync(f, JSON.stringify(rtmStartData, null, 2));
         }
         this.data = rtmStartData;
+        this.data.channels = this.data.channels.concat(this.data.groups); // we want the hidden channels, "groups", too!
       });
 
       // you need to wait for the client to fully connect before you can send messages
@@ -55,15 +57,32 @@ class Client extends EventEmitter {
 
       this.rtm.on(CLIENT_EVENTS.RTM.RAW_MESSAGE, (payload) => {
         let data = JSON.parse(payload);
+        //console.log(data);
         if ( data.type === "message" ) {
           debug('emitting message:', data);
           this.emit('message', data);
         } else if (data.type === 'channel_joined') {
           this.data.channels.push(data.channel);
+        } else if (data.type === 'group_joined') {
+          this.data.channels.push(data.channel);
         } else if (data.type === 'reconnect_url') {
           // ignore
         } else if (data.type === 'pong') {
           // ignore
+        } else if (data.type === 'team_join') {
+          this.data.users.push(data.user);
+        } else if (data.type === 'user_change') {
+          let found = false;
+          for (let i = 0; i < this.data.users.length; i++) {
+            if (this.data.users[i].id == data.user.id) {
+              this.data.users[i] = data.user.id;
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            this.data.users.push(data.user);
+          }
         } else {
           debug('raw message, type:', data.type);
         }
@@ -95,7 +114,7 @@ class Client extends EventEmitter {
     return this.data.bots.find(u => u.id === id) || { name: "unknown" };
   }
   getUserById(id) {
-    return this.data.users.find(u => u.id === id) || { name: "unknown" };
+    return this.data.users.find(u => u.id === id);
   }
   getChannelById(id) {
     return this.data.channels.find(c => c.id === id);
@@ -135,19 +154,25 @@ class Client extends EventEmitter {
    * Attachments are pretty cool, check it here:
    * https://api.slack.com/docs/messages/builder
    */
-  sendPictureMessage(imageUrl, channel) {
+  sendImageMessage(imageUrl, title, channel) {
     return new Promise((resolve, reject) => {
       this.web.chat.postMessage(channel, null, {
         as_user: true,
         attachments:[
           {
             fallback: imageUrl,
-            image_url: imageUrl
+            image_url: imageUrl,
+            title: title
           }
         ]
       }, (err, res) => {
         err ? reject(err) : resolve(res);
       });
+    });
+  }
+  downloadImage(url) {
+    return download.getBufferAndType(url, {
+      headers: { Authorization: 'Bearer ' +  this.token}
     });
   }
 }

--- a/client.js
+++ b/client.js
@@ -155,12 +155,13 @@ class Client extends EventEmitter {
    * https://api.slack.com/docs/messages/builder
    */
   sendImageMessage(imageUrl, title, channel) {
+    console.log(imageUrl);
     return new Promise((resolve, reject) => {
       this.web.chat.postMessage(channel, null, {
         as_user: true,
         attachments:[
           {
-            fallback: imageUrl,
+            fallback: title,
             image_url: imageUrl,
             title: title
           }

--- a/client.js
+++ b/client.js
@@ -155,7 +155,6 @@ class Client extends EventEmitter {
    * https://api.slack.com/docs/messages/builder
    */
   sendImageMessage(imageUrl, title, channel) {
-    console.log(imageUrl);
     return new Promise((resolve, reject) => {
       this.web.chat.postMessage(channel, null, {
         as_user: true,

--- a/client.js
+++ b/client.js
@@ -75,7 +75,7 @@ class Client extends EventEmitter {
           let found = false;
           for (let i = 0; i < this.data.users.length; i++) {
             if (this.data.users[i].id == data.user.id) {
-              this.data.users[i] = data.user.id;
+              this.data.users[i] = data.user;
               found = true;
               break;
             }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   "dependencies": {
     "@slack/client": "^3.8.1",
     "bluebird": "^3.4.7",
-    "matrix-puppet-bridge": "~1.10.0",
+    "concat-stream": "^1.6.0",
+    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#d5af7b9",
+    "mime-types": "^2.1.14",
+    "needle": "^1.4.5",
     "showdown": "^1.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@slack/client": "^3.8.1",
     "bluebird": "^3.4.7",
     "concat-stream": "^1.6.0",
+    "emojione": "^3.1.1",
     "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#d5af7b9",
     "mime-types": "^2.1.14",
     "needle": "^1.4.5",

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,40 @@
+const Promise = require('bluebird');
+const concatStream = require('concat-stream');
+const needle = require('needle');
+const mime = require('mime-types');
+const urlParse = require('url').parse;
+
+const downloadGetStream = (url, data) => needle.get(url, data);
+
+const downloadGetBufferAndHeaders = (url, data) => {
+  return new Promise((resolve, reject) => {
+    let headers = {
+      'content-type': 'application/octet-stream'
+    };
+    let stream = downloadGetStream(url, data);
+    stream.on('header', (_s, _h) => headers = _h);
+    stream.pipe(concatStream((buffer)=>{
+      resolve({ buffer, headers });
+    })).on('error', reject);
+  });
+};
+
+const downloadGetBufferAndType = (url, data) => {
+  return downloadGetBufferAndHeaders(url, data).then(({ buffer, headers }) => {
+    let type, contentType = headers['content-type'];
+    if ( contentType ) {
+      type = contentType;
+    } else {
+      type = mime.lookup(urlParse(url).pathname);
+    }
+    type = type.split(';')[0];
+    return { buffer, type };
+  });
+};
+
+module.exports = {
+  download: {
+    getStream: downloadGetStream,
+    getBufferAndType: downloadGetBufferAndType,
+  },
+};


### PR DESCRIPTION
This will:
 - Upload images directly to matrix instead of just linking them
 - Sync avatars
 - Convert emojis
 - Support restricted chanels ("groups")
 - Update to the latest matrix-puppet-bridge to actually make avatars working

This fixes:
 - #20 
 - #19 
 - #11