### PR TITLE
Bump matrix-puppet-bridge patch version for bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bluebird": "^3.4.7",
     "concat-stream": "^1.6.0",
     "emojione": "^3.1.1",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#d5af7b9",
+    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#cf7976e",
     "mime-types": "^2.1.14",
     "needle": "^1.4.5",
     "showdown": "^1.6.4"


### PR DESCRIPTION
Pulls in [an update](https://github.com/matrix-hacks/matrix-puppet-bridge/commit/39144bcaa2d6e448507631e8b5269e4ee30b6343) that addresses #23 