### PR TITLE
develop_new: Handle all known Slack Attachments attributes in messages (e.g. fancy bot/integration/app messages) and handle Slack's permissive ``` block syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,8 +204,8 @@ export class Adapter extends ThirdPartyAdapter {
     
     let rawMessage =
       messages
-        .map(m => m.trim())
         .filter(m => m && (typeof m === "string"))
+        .map(m => m.trim())
         .join('\n')
         .trim();
     let payload = <ThirdPartyMessagePayload>this.getPayload(data);

--- a/src/slacktomd.ts
+++ b/src/slacktomd.ts
@@ -78,6 +78,8 @@ export class slacktomd {
   }
 
   _markdownTag(tag, payload, linkText = '') {
+    payload = payload.toString();
+
     if(!linkText) {
       linkText = payload;
     }
@@ -90,7 +92,7 @@ export class slacktomd {
       case "fixed":
         return "`" + payload + "`";
       case "blockFixed":
-        return "```" + payload + "```";
+        return "```\n" + payload.trim() + "\n```";
       case "strike":
         return "~~" + payload + "~~";
       case "href":


### PR DESCRIPTION
Adds support for [these](https://api.slack.com/docs/messages/builder?msg=%7B%22attachments%22%3A%5B%7B%22fallback%22%3A%22fallback%22%2C%22color%22%3A%22%2336a64f%22%2C%22pretext%22%3A%22pretext%22%2C%22author_name%22%3A%22author_name%22%2C%22author_link%22%3A%22http%3A%2F%2Fflickr.com%2Fbobby%2F%22%2C%22author_icon%22%3A%22http%3A%2F%2Fflickr.com%2Ficons%2Fbobby.jpg%22%2C%22title%22%3A%22title%22%2C%22title_link%22%3A%22https%3A%2F%2Fapi.slack.com%2F%22%2C%22text%22%3A%22text%22%2C%22fields%22%3A%5B%7B%22title%22%3A%22fields%5B1%5D.title%22%2C%22value%22%3A%22fields%5B1%5D.value%22%2C%22short%22%3Afalse%7D%5D%2C%22image_url%22%3A%22http%3A%2F%2Fmy-website.com%2Fpath%2Fto%2Fimage.jpg%22%2C%22thumb_url%22%3A%22http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fthumb.png%22%2C%22footer%22%3A%22footer%22%2C%22footer_icon%22%3A%22https%3A%2F%2Fplatform.slack-edge.com%2Fimg%2Fdefault_application_icon.png%22%2C%22ts%22%3A123456789%7D%5D%7D) attributes of Slack message "attachment" attributes, plus read-only support for ["actions"](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22Would%20you%20like%20to%20play%20a%20game%3F%22%2C%22attachments%22%3A%5B%7B%22text%22%3A%22Choose%20a%20game%20to%20play%22%2C%22fallback%22%3A%22You%20are%20unable%20to%20choose%20a%20game%22%2C%22callback_id%22%3A%22wopr_game%22%2C%22color%22%3A%22%233AA3E3%22%2C%22attachment_type%22%3A%22default%22%2C%22actions%22%3A%5B%7B%22name%22%3A%22game%22%2C%22text%22%3A%22Chess%22%2C%22type%22%3A%22button%22%2C%22value%22%3A%22chess%22%7D%2C%7B%22name%22%3A%22game%22%2C%22text%22%3A%22Falken%27s%20Maze%22%2C%22type%22%3A%22button%22%2C%22value%22%3A%22maze%22%7D%2C%7B%22name%22%3A%22game%22%2C%22text%22%3A%22Thermonuclear%20War%22%2C%22style%22%3A%22danger%22%2C%22type%22%3A%22button%22%2C%22value%22%3A%22war%22%2C%22confirm%22%3A%7B%22title%22%3A%22Are%20you%20sure%3F%22%2C%22text%22%3A%22Wouldn%27t%20you%20prefer%20a%20good%20game%20of%20chess%3F%22%2C%22ok_text%22%3A%22Yes%22%2C%22dismiss_text%22%3A%22No%22%7D%7D%5D%7D%5D%7D).

Before, many of these attributes were ignored, causing messages (mostly integration/bot/app messages) to be missing parts, or appear entirely blank.

Some hacks were made to keep the changes local to one section of one file, reducing churn. The hacks, and what we can do to fix them in the immediate future, are described in a FIXME.

This is an untested port of the same changes made to a branch of master, where they're confirmed working.