### PR TITLE
Convert Slack's <!channel> to @room

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,10 @@ export class Adapter extends ThirdPartyAdapter {
         [':skin-tone-4:', '🏽'],
         [':skin-tone-5:', '🏾'],
         [':skin-tone-6:', '🏿'],
+        ['<!channel>', '@room'],
+          // NOTE: <!channel> is converted to @room here,
+          // and not in slacktomd, because we're translating Slack parlance
+          // to Matrix parlance, not parsing "Slackdown" to turn into Markdown.
       ];
       for (let i = 0; i < replacements.length; i++) {
         rawMessage = rawMessage.replace(replacements[i][0], replacements[i][1]);


### PR DESCRIPTION
Currently, it gets parsed as a Slack tag and turned into "!channel", which does not notify by default in Matrix (or at least in Riot).