### PR TITLE
Fix port number to match README.md

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -4,11 +4,10 @@
     "user_access_token": "<slack 'test' token>"
   }],
   "registrationPath": "slack-registration.yaml",
-  "port": 8092,
+  "port": 8090,
   "bridge": {
     "homeserverUrl":"https://synapse.keyvan.pw",
     "domain": "synapse.keyvan.pw",
     "registration": "slack-registration.yaml"
   }
 }
-


### PR DESCRIPTION
This port number should be consistent with the line in the README.md where it says: ```Generate an `slack-registration.yaml` file with `node index.js -r -u "http://your-bridge-server:8090"````