### PR TITLE
Backport features to master

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,8 @@ const slackdown = require('./slackdown');
 const showdown  = require('showdown');
 const emojione = require('emojione')
 const converter = new showdown.Converter({
-  literalMidWordUnderscores : true
+  literalMidWordUnderscores : true,
+  simpleLineBreaks: true
 });
 
 class App extends MatrixPuppetBridgeBase {
@@ -152,9 +153,75 @@ class App extends MatrixPuppetBridgeBase {
     // any direct text
     let messages = [text];
     // any attachments, stuff it into the text as new lines
-    if (attachments) attachments.forEach(att=> messages.push(att.text))
+    if (attachments) {
+      /* FIXME: Right now, doing this properly would cause too much churn.
+       * The attachments are also in Slack's markdown-like
+       * formatting, not real markdown, but they require features
+       * (e.g. links with custom text) that Slack formatting doesn't support.
+       * Because we need to process the "slackdown", but also implement those
+       * features, we mix in some real markdown that makes it past our
+       * slackdown-to-markdown converter. We also need <font> tags for our
+       * colorization, but the converter can't handle the raw HTML (which
+       * slackdown doesn't allow), and we don't want to turn HTML in Slack
+       * messages into real HTML (it should show as plaintext just like it
+       * does in Slack, lest we try to turn "</sarcasm>" into real end tags),
+       * so we hack around it by implementing our own silly font color hack.
+       * A good fix would be to parse individual messages' slackdown
+       * to markdown, and add the additional markdown
+       * (including raw HTML tags) afterward, instead of forming a big array
+       * of slackdown messages, then converting them all into markdown at once.
+       */
+      attachments.forEach(att=> {
+        let attMessages = [];
+        if (att.pretext) {
+          messages.push(att.pretext);
+        }
+        if (att.author_name) {
+          if (att.author_link) {
+            attMessages.push(`[${att.author_name}](${att.author_link})`);
+          } else {
+            attMessages.push(`${att.author_name}`);
+          }
+        }
+        if (att.title) {
+          if (att.title_link) {
+            attMessages.push(`*[${att.title}](${att.title_link})*`);
+          } else {
+            attMessages.push(`*${att.title}*`);
+          }
+        }
+        if (att.text) {
+          attMessages.push(`${att.text}`);
+        }
+        if (att.fields) {
+          att.fields.forEach(field => {
+            if (field.title) {
+              attMessages.push(`*${field.title}*`);
+            }
+            if (field.value) {
+              attMessages.push(`${field.value}`);
+            }
+          })
+        }
+        if ((att.actions instanceof Array) && att.actions.length > 0) {
+          attMessages.push(`Actions (Unsupported): ${att.actions.map(o => `[${o.text}]`).join(" ")}`);
+        }
+        if (att.footer) {
+          attMessages.push(`_${att.footer}_`);
+        }
+        let attachmentBullet = att.color ? `;BEGIN_FONT_COLOR_HACK_${att.color};●;END_FONT_COLOR_HACK;` : "●";
+        attMessages.forEach(attMessage => {
+          messages.push(`${attachmentBullet} ${attMessage}`);
+        });
+      });
+    }
 
-    let rawMessage = messages.join('\n').trim();
+    let rawMessage =
+      messages
+        .map(m => m.trim())
+        .filter(m => m && (typeof m === "string"))
+        .join('\n')
+        .trim();
     let payload = this.getPayload(data);
 
     try {
@@ -176,6 +243,8 @@ class App extends MatrixPuppetBridgeBase {
       }
       rawMessage = emojione.shortnameToUnicode(rawMessage);
       payload.text = slackdown(rawMessage, this.client.getUsers(), this.client.getChannels());
+      payload.text = payload.text.replace(/;BEGIN_FONT_COLOR_HACK_(.*?);/g, '<font color="$1">');
+      payload.text = payload.text.replace(/;END_FONT_COLOR_HACK;/g, '</font>');
       payload.html = converter.makeHtml(payload.text);
     } catch (e) {
       console.log(e);

--- a/app.js
+++ b/app.js
@@ -218,8 +218,8 @@ class App extends MatrixPuppetBridgeBase {
 
     let rawMessage =
       messages
-        .map(m => m.trim())
         .filter(m => m && (typeof m === "string"))
+        .map(m => m.trim())
         .join('\n')
         .trim();
     let payload = this.getPayload(data);

--- a/app.js
+++ b/app.js
@@ -237,6 +237,10 @@ class App extends MatrixPuppetBridgeBase {
         [':skin-tone-4:', '🏽'],
         [':skin-tone-5:', '🏾'],
         [':skin-tone-6:', '🏿'],
+        ['<!channel>', '@room'],
+          // NOTE: <!channel> is converted to @room here,
+          // and not in slacktomd, because we're translating Slack parlance
+          // to Matrix parlance, not parsing "Slackdown" to turn into Markdown.
       ];
       for (let i = 0; i < replacements.length; i++) {
         rawMessage = rawMessage.replace(replacements[i][0], replacements[i][1]);

--- a/app.js
+++ b/app.js
@@ -245,11 +245,14 @@ class App extends MatrixPuppetBridgeBase {
       console.log("rawMessage");
       console.log(rawMessage);
       payload.text = slackdown(rawMessage, this.client.getUsers(), this.client.getChannels());
-      payload.text = payload.text.replace(/;BEGIN_FONT_COLOR_HACK_(.*?);/g, '<font color="$1">');
-      payload.text = payload.text.replace(/;END_FONT_COLOR_HACK;/g, '</font>');
+      let markdown = payload.text
+      markdown = markdown.replace(/;BEGIN_FONT_COLOR_HACK_(.*?);/g, '<font color="$1">');
+      markdown = markdown.replace(/;END_FONT_COLOR_HACK;/g, '</font>');
+      payload.text = payload.text.replace(/;BEGIN_FONT_COLOR_HACK_(.*?);/g, '');
+      payload.text = payload.text.replace(/;END_FONT_COLOR_HACK;/g, '');
       console.log("payload.text");
       console.log(payload.text);
-      payload.html = converter.makeHtml(payload.text);
+      payload.html = converter.makeHtml(markdown);
       console.log("payload.html");
       console.log(payload.html);
     } catch (e) {

--- a/app.js
+++ b/app.js
@@ -242,10 +242,16 @@ class App extends MatrixPuppetBridgeBase {
         rawMessage = rawMessage.replace(replacements[i][0], replacements[i][1]);
       }
       rawMessage = emojione.shortnameToUnicode(rawMessage);
+      console.log("rawMessage");
+      console.log(rawMessage);
       payload.text = slackdown(rawMessage, this.client.getUsers(), this.client.getChannels());
       payload.text = payload.text.replace(/;BEGIN_FONT_COLOR_HACK_(.*?);/g, '<font color="$1">');
       payload.text = payload.text.replace(/;END_FONT_COLOR_HACK;/g, '</font>');
+      console.log("payload.text");
+      console.log(payload.text);
       payload.html = converter.makeHtml(payload.text);
+      console.log("payload.html");
+      console.log(payload.html);
     } catch (e) {
       console.log(e);
       debug("could not normalize message", e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-puppet-slack",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/slacktomd.js
+++ b/slacktomd.js
@@ -78,6 +78,8 @@ class slacktomd {
   }
 
   _markdownTag(tag, payload, linkText) {
+    payload = payload.toString();
+
     if(!linkText) {
       linkText = payload;
     }
@@ -93,7 +95,7 @@ class slacktomd {
         return "`" + payload + "`";
         break;
       case "blockFixed":
-        return "```" + payload + "```";
+        return "```\n" + payload.trim() + "\n```";
         break;
       case "strike":
         return "~~" + payload + "~~";


### PR DESCRIPTION
Bumps version to 1.6.0 and backports these features from recent work to master:
- Handling of more attachment types (this gets a lot of bots working)
- Handling of Slack's permissive ``` block syntax
- Converting <!channel> to @room (though the bridge doesn't create rooms in which ordinary users can @room, so this doesn't fully work)