### PR TITLE
Split html case and normal case

### DIFF
--- a/app.js
+++ b/app.js
@@ -316,12 +316,17 @@ class App extends MatrixPuppetBridgeBase {
   sendMessageAsPuppetToThirdPartyRoomWithId(id, text, data) {
     debug('sending message as puppet to third party room with id', id);
     // text lost html informations, just use raw message instead that.
-    const rawMessage = data.content.formatted_body || data.content.body;
+    let message;
+    if (data.content.format === 'org.matrix.custom.html') {
+      const rawMessage = data.content.formatted_body;
 
-    console.log("rawMessage");
-    console.log(rawMessage);
+      console.log("rawMessage");
+      console.log(rawMessage);
 
-    let message = mxtoslack(this, rawMessage);
+      message = mxtoslack(this, rawMessage);
+    } else {
+      message = data.content.body;
+    }
 
     const replacements = [
       ['@room', this.notifyToSlack !== 'only_active' ? '<!channel>' : '<!here>'],


### PR DESCRIPTION
only needs markdown transform that string type is `org.matrix.custom.html`.
for example if html has `<br>` it will replace to norml `\n` after transform.
but if normal text type, it will lose linefeed after transform