### PR TITLE
Register alias namespace (Fixes #73)

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ new Cli({
       reg.setAppServiceToken(AppServiceRegistration.generateToken());
       reg.setSenderLocalpart(`slack_bot`);
       reg.addRegexPattern("users", `@slack_.*`, true);
+      reg.addRegexPattern("aliases", `@slack_.*`, false);
       callback(reg);
     }).catch(err=>{
       console.error(err.message);


### PR DESCRIPTION
This should fix #73 and #72

I'm not entirely sure about the exclusivity of the aliases namespace.
I have the feeling that we will not be able to initiate room joins or DM's with `exclusive: true`.