### PR TITLE
Add badge to README with link to room

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# matrix-puppet-slack
+# matrix-puppet-slack [![#matrix-puppet-bridge:matrix.org](https://img.shields.io/matrix/matrix-puppet-bridge:matrix.org.svg?label=%23matrix-puppet-bridge%3Amatrix.org&logo=matrix&server_fqdn=matrix.org)](https://matrix.to/#/#matrix-puppet-bridge:matrix.org)
 
 This is an unofficial matrix slack bridge that works by means of [user puppetting](https://github.com/AndrewJDR/matrix-puppet-bridge).
 
@@ -40,7 +40,7 @@ Restart your HS.
 
 ## Discussion, Help and Support
 
-Join us in [the Matrix Puppet Bridge room](https://riot.im/app/#/room/#matrix-puppet-bridge:matrix.org)
+Join us in the [![Matrix Puppet Bridge](https://user-images.githubusercontent.com/13843293/52007839-4b2f6580-24c7-11e9-9a6c-14d8fc0d0737.png)](https://matrix.to/#/#matrix-puppet-bridge:matrix.org) room
 
 ## Features and Roadmap
 


### PR DESCRIPTION
Not 100% sure how I feel about trusting GitHub to host that user-images.githubusercontent.com file but I guess it works. I also added the more standard badge to the top of the README.

If this looks good I'll submit a PR to the other puppet bridge repos.



discussed here: https://github.com/matrix-hacks/matrix-puppet-slack/commit/1d9669ebe9a3d93a603107603d8b450898a04ae3