### PR TITLE
In registration file, use prefix character for rooms in room alias reservation field

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ new Cli({
       reg.setAppServiceToken(AppServiceRegistration.generateToken());
       reg.setSenderLocalpart(`slack_bot`);
       reg.addRegexPattern("users", `@slack_.*`, true);
-      reg.addRegexPattern("aliases", `@slack_.*`, false);
+      reg.addRegexPattern("aliases", `#slack_.*`, false);
       callback(reg);
     }).catch(err=>{
       console.error(err.message);


### PR DESCRIPTION
This should fix #72.  Tested working on my server (generated an old reg file & confirmed that I get the error in #72; applied this modification, regenerated the reg file, and restarted synapse; confirmed that I did not anymore).

Also, this pattern can be seen in the bottom of the Matrix Application Service spec at the bottom of 2.1 (https://matrix.org/docs/spec/application_service/unstable.html#registration)