### PR TITLE
Fix room aliases, improve attachment handling for Slack -> Matrix

### DIFF
--- a/app.js
+++ b/app.js
@@ -183,7 +183,7 @@ class App extends MatrixPuppetBridgeBase {
     return this.client.downloadImage(data.file.url_private).then(({ buffer, type }) => {
       payload.buffer = buffer;
       payload.mimetype = type;
-      return this.handleThirdPartyRoomImageMessage(payload);
+      return this.handleThirdPartyRoomMessageWithAttachment(payload);
     }).catch((err) => {
       console.log(err);
       payload.text = '[Image] ('+data.name+') '+data.url;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bluebird": "^3.4.7",
     "concat-stream": "^1.6.0",
     "emojione": "^3.1.1",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#2dca836",
+    "matrix-puppet-bridge": "github:michaelnew/matrix-puppet-bridge",
     "mime-types": "^2.1.14",
     "needle": "^1.4.5",
     "showdown": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bluebird": "^3.4.7",
     "concat-stream": "^1.6.0",
     "emojione": "^3.1.1",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#219d46f",
+    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#186331f",
     "mime-types": "^2.1.14",
     "needle": "^1.4.5",
     "showdown": "^1.6.4",


### PR DESCRIPTION
Two simple fixes:  
* point package.json to the latest matrix-puppet-bridge to include [this](https://github.com/matrix-hacks/matrix-puppet-bridge/pull/69) fix for room aliases
* Use `handleThirdPartyRoomMessageWithAttachment` rather than `handleThirdPartyRoomImageMessage` to better handle incoming message attachements (image, video, files, etc.)